### PR TITLE
Add support for selectable begin-end widget method

### DIFF
--- a/Selectable.php
+++ b/Selectable.php
@@ -42,12 +42,46 @@ use yii\helpers\Html;
  * ]);
  * ```
  *
+ * Selectable in begin mode.
+ *
+ * ```php
+ * Selectable::begin([
+ *     'clientOptions' => [
+ *         'filter' => 'my-selectable-item'
+ *         'tolerance' => 'fit',
+ *     ],
+ * ]);
+ * ```
+ * <ul>
+ *      <li class="my-selectable-item">Item 1</li>
+ *      <li class="my-selectable-item">Item 2</li>
+ *      <li class="no-selectable-item">Item 3</li>
+ *      <li class="my-selectable-item">Item 4</li>
+ * </ul>
+ * <div>
+ *      <div>
+ *          <div class="my-selectable-item">Another item</div>
+ *      </div>
+ * </div>
+ *
+ * ```php
+ * Selectable::end();
+ * ```
+ *
  * @see http://api.jqueryui.com/selectable/
  * @author Alexander Kochetov <creocoder@gmail.com>
  * @since 2.0
  */
 class Selectable extends Widget
 {
+    const MODE_DEFAULT = 'MODE_DEFAULT';
+    const MODE_BEGIN = 'MODE_BEGIN';
+
+    /**
+     * @var string the mode used to render the widget.
+     */
+    public $mode = self::MODE_DEFAULT;
+    
     /**
      * @var array the HTML attributes for the widget container tag. The following special options are recognized:
      *
@@ -79,17 +113,51 @@ class Selectable extends Widget
      */
     public $itemOptions = [];
 
+    /**
+     * Begins a widget.
+     * This method creates an instance of the calling class setting the MODE_BEGIN mode. Any item between 
+     * [[begin()]] and [[end()]] which match the filter attribute, will be selectable. 
+     * It will apply the configuration
+     * to the created instance. A matching [[end()]] call should be called later.
+     * As some widgets may use output buffering, the [[end()]] call should be made in the same view
+     * to avoid breaking the nesting of output buffers.
+     * @param array $config name-value pairs that will be used to initialize the object properties
+     * @return static the newly created widget instance
+     * @see end()
+     */
+    public static function begin($config = []) {
+        $config['mode'] = self::MODE_BEGIN;
 
+        parent::begin($config);
+    }
+    
+    /**
+     * Initializes the widget.
+     */
+    public function init()
+    {
+        parent::init();
+
+        if ($this->mode === self::MODE_BEGIN) {
+            echo Html::beginTag('div', $this->options) . "\n";
+        }
+    }
+    
     /**
      * Renders the widget.
      */
     public function run()
     {
-        $options = $this->options;
-        $tag = ArrayHelper::remove($options, 'tag', 'ul');
-        echo Html::beginTag($tag, $options) . "\n";
-        echo $this->renderItems() . "\n";
-        echo Html::endTag($tag) . "\n";
+        if ($this->mode === self::MODE_BEGIN) {
+            echo Html::endTag('div') . "\n";
+        } else {
+            $options = $this->options;
+            $tag = ArrayHelper::remove($options, 'tag', 'ul');
+            echo Html::beginTag($tag, $options) . "\n";
+            echo $this->renderItems() . "\n";
+            echo Html::endTag($tag) . "\n";
+        }
+        
         $this->registerWidget('selectable');
     }
 


### PR DESCRIPTION
New release to allow to make selectable any item between the begin() and end() widget calls matching the filter attribute value selector.

Uses:

``` php
Selectable::begin([
     'clientOptions' => [
         'filter' => 'my-selectable-item'
         'tolerance' => 'fit',
     ],
 ]);
```

``` html
<ul>
      <li class="my-selectable-item">Item 1</li>
      <li class="my-selectable-item">Item 2</li>
      <li class="no-selectable-item">Item 3</li>
      <li class="my-selectable-item">Item 4</li>
 </ul>
 <div>
      <div>
          <div class="my-selectable-item">Another item </div>
      </div>
 </div>
```

``` php
 Selectable::end();
```
